### PR TITLE
fix: 連続するダブルコーテーションを含むと適切にエスケープされないため--body-fileを使うように

### DIFF
--- a/.github/actions/create-release-pr-for-gem/action.yml
+++ b/.github/actions/create-release-pr-for-gem/action.yml
@@ -62,10 +62,8 @@ runs:
       env:
         GH_TOKEN: ${{ env.GITHUB_TOKEN }}
       run: |
-        BODY=$(cat <<EOF
+        cat <<EOF > /tmp/pr_body.txt
         ${{ steps.changelog.outputs.clean_changelog }}
         EOF
-        )
-        ESCAPED_BODY=$(echo "$BODY" | sed 's/"/\\"/g')
-        gh pr create --title "chore: Release version to v${{ steps.changelog.outputs.version }}" --body "$ESCAPED_BODY" --base ${{ inputs.base-branch }} --head release/${{ inputs.tag-prefix }}${{ steps.changelog.outputs.version }}
+        gh pr create --title "chore: Release version to v${{ steps.changelog.outputs.version }}" --body-file /tmp/pr_body.txt --base ${{ inputs.base-branch }} --head release/${{ inputs.tag-prefix }}${{ steps.changelog.outputs.version }}
       shell: bash


### PR DESCRIPTION
## 概要
skp-report-metricsでcreate gem release PRを実行したところ連続したダブルコーテーションを含むcommitがあると以下のようにsyntaxエラーになってしまったので、対応します。

https://github.com/pinnacles/skp-report-metrics/actions/runs/19485274506/job/55766104079

## 詳細
エスケープせず内容をtmpfileにして--body-fileで渡すようにしました